### PR TITLE
Release 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,21 +195,6 @@ Example above may be used during system startup to perform global change, but if
 (call-with handler inc) ;; throws ArityException, as inc requires more than 1 argument
 ```
 
-Custom handler may be also passed to `flet` in first pair of binding vector:
-```clojure
-;; this flet works the same as let if exception occured
-(flet [:caught #(throw %)
-       a 1
-       b (/ a 0)]
-  (+ a b)) ;; throws ArithmeticException
-
-;; but it can do early return if exception is returned as value
-(flet [:caught #(throw %)
-       a 1
-       b (ex-info "Something went wrong" {:because "Monday"})]
-  (/ a b)) ;; => #error {:cause "Something went wrong" :data {:because "Monday"} ... }
-```
-
 ## FAQ
 
 ### How it's different from Either?

--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]]
   :plugins [[lein-doo "0.1.11"]]
-  :java-source-paths ["src/fmnoise/flow"]
-  :javac-options ["-target" "1.7", "-source" "1.7"])
+  :java-source-paths ["src/fmnoise/flow"])

--- a/src/fmnoise/flow.cljc
+++ b/src/fmnoise/flow.cljc
@@ -54,19 +54,34 @@
      (caught [t] t)))
 
 #?(:clj
-   (defn fail-with
+   (defn ^Fail fail-with
      "Constructs `Fail` with given options. Stacktrace is disabled by default"
      {:added "2.0"}
      [{:keys [msg data cause suppress? trace?] :or {data {} suppress? false trace? false} :as options}]
      {:pre [(or (nil? options) (map? options))]}
-     (Fail. msg data cause suppress? trace?)))
+     (Fail. msg data cause suppress? trace?))
+
+   :cljs
+   (defn fail-with
+     "Constructs `ex-info` with given options"
+     {:added "4.2"}
+     [{:keys [msg data cause] :or {data {}} :as options}]
+     {:pre [(or (nil? options) (map? options))]}
+     (ex-info msg data cause)))
 
 #?(:clj
    (defn fail-with!
-     "Constructs `Fail` with given options and throws it. Stacktrace is enabled by default."
+     "Constructs `Fail` with given options and throws it. Stacktrace is enabled by default. See `fail-with` for more details"
      {:added "2.0"}
-     [{:keys [trace?] :or {trace? true} :as options}]
-     (throw (fail-with (assoc options :trace? trace?)))))
+     [{:keys [msg data cause suppress? trace?] :or {trace? true} :as options}]
+     (throw (fail-with (assoc options :trace? trace?))))
+
+   :cljs
+   (defn fail-with!
+     "Constructs `ex-info` with given options and throws it. See `fail-with` for more details"
+     {:added "4.2"}
+     [{:keys [msg data cause] :as options}]
+     (throw (fail-with options))))
 
 (defn fail?
   "Checks if given value is considered as failure"

--- a/src/fmnoise/flow.cljc
+++ b/src/fmnoise/flow.cljc
@@ -10,16 +10,16 @@
    (extend-protocol Flow
      java.lang.Object
      (?ok [this f] (f this))
-     (?err [this f] this)
+     (?err [this _] this)
      (?throw [this] this)
 
      nil
      (?ok [this f] (f this))
-     (?err [this f] this)
+     (?err [this _] this)
      (?throw [this] this)
 
      java.lang.Throwable
-     (?ok [this f] this)
+     (?ok [this _] this)
      (?err [this f] (f this))
      (?throw [this] (throw this)))
 
@@ -27,16 +27,16 @@
    (extend-protocol Flow
      object
      (?ok [this f] (f this))
-     (?err [this f] this)
+     (?err [this _] this)
      (?throw [this] this)
 
      nil
      (?ok [this f] (f this))
-     (?err [this f] this)
+     (?err [this _] this)
      (?throw [this] this)
 
      js/Error
-     (?ok [this f] this)
+     (?ok [this _] this)
      (?err [this f] (f this))
      (?throw [this] (throw this))))
 

--- a/test/fmnoise/flow_test.cljc
+++ b/test/fmnoise/flow_test.cljc
@@ -243,34 +243,6 @@
     (let [err (ex-info "oops" {})]
       (is (= err (f/flet [x (+ 1 2), y 0] err)))))
 
-  (testing "with custom handler"
-    (let [handler #(throw %)]
-      (testing "with no exception"
-        (is (= 6 (f/flet [:caught handler
-                          x (+ 1 2)
-                          y (+ x 3)]
-                   y))))
-
-      (testing "with exception in bindings"
-        (is (thrown? ArithmeticException (f/flet [:caught handler
-                                                  x (+ 1 2)
-                                                  y (/ x 0)]
-                                           y))))
-
-      (testing "with error returned in bindings"
-        (let [err (ex-info "oops" {})]
-          (is (= err (f/flet [:caught handler, x (+ 1 2), y err] x)))))
-
-      (testing "with exception in body"
-        (is (thrown? ArithmeticException (f/flet [:caught handler
-                                                  x (+ 1 2)
-                                                  y 0]
-                                           (/ x y)))))
-
-      (testing "with error returned in body"
-        (let [err (ex-info "oops" {})]
-          (is (= err (f/flet [:caught handler, x (+ 1 2), y 3] err)))))))
-
   (testing "duplicate field name and signature error"
     (is (= 3 (f/flet [a_b 1 a-b 2 c 3] (+ a-b a_b))))))
 


### PR DESCRIPTION
- remove 1.7 java target in compiler options
- Implement `fail-with` and `fail-with!` for CLJS
- **BREAKING** Remove catch-handler for `flet`
- remove CLJS reader conditionals for `flet` because it doesn't work anyways
